### PR TITLE
Update pSlackWebhookUrl parameter type

### DIFF
--- a/cloudformation/AccountAlertTopics-Template.yaml
+++ b/cloudformation/AccountAlertTopics-Template.yaml
@@ -33,7 +33,7 @@ Parameters:
   # Slack Parameters passed as Env Vars to Lambda
   pSlackWebhookURL:
     Description: WebHook URL from Slack. Keep this secret
-    Type: 'AWS::SSM::Parameter::Value<String>'
+    Type: String
     Default: SlackWebhook
 
   pSlackChannel:


### PR DESCRIPTION
The SlackWebhookUrl parameter should be a secret however cloudformation
does not support SecureString type.  When this param is stored in
SSM as a SecureString CF will fail to retreive the value with the
following error:

"An error occurred (ValidationError) when calling the CreateStack
operation: Parameters [/bridge/SlackWebhookUrl] referenced by
template have types not supported by CloudFormation."

Change it the type to String so that CF won't attempt to lookup the
param value from the parameter store.