### PR TITLE
Use true/false for boolean params

### DIFF
--- a/cloudformation/AccountAlertTopics-Template.yaml
+++ b/cloudformation/AccountAlertTopics-Template.yaml
@@ -13,10 +13,10 @@ Parameters:
   pEnableSubscriberSMS:
     Description: Enable SMS notification of critical alerts
     Type: String
-    Default: yes
+    Default: true
     AllowedValues:
-    - yes
-    - "no"
+      - true
+      - false
 
   pInitialSubscriberSMS:
     Description: Add this initial Cell for SMS notification of critical alerts
@@ -31,8 +31,8 @@ Parameters:
     Description: Whether or not to deploy the slack lambda
     Type: String
     AllowedValues:
-    - yes
-    - "no"
+      - true
+      - false
 
   pLambdaFunctionName:
     Description: Name of the Lambda Function


### PR DESCRIPTION
Using yes/no for the purpose of a boolean parameter does not
work.  You need to use true/false even though AWS treats it
as a 'String' type.